### PR TITLE
Create activateFabricBot.yml

### DIFF
--- a/policies/activateFabricBot.yml
+++ b/policies/activateFabricBot.yml
@@ -1,0 +1,8 @@
+name: Fabric Bot
+description: Description
+
+resource: repository
+
+configuration:
+  activateFabricBot:
+    activate: true


### PR DESCRIPTION
Hello! This PR is to convert the existing FabricBot users inside of the OneDrive org to the new gitops-based FabricBot; while this file activates it org wide, it'll only act on repositories with an existing FabricBot configuration. Existing workflows should work the same, but the new FabricBot has a host of new features on a much more maintainable and scalable code base.

The plan is to prep this PR for merging and 'swap' (IE, deactivate the old FabricBot and merge) on February 1st. Please let me know if you have any questions/comments/etc!